### PR TITLE
Random Selection from N Vertical Bar Separated Words

### DIFF
--- a/config/sentence-structure.cfg
+++ b/config/sentence-structure.cfg
@@ -19,3 +19,4 @@ Among these were a couple of [plural_noun], a [verb_ing] [noun] I employed [freq
 The [noun] was [verb_ing] [adverb]
 The [noun] in [country] is [adjective]
 The [noun] is colour [colour] COLOUR
+This is a random string from 1 to 4 [one|two|three|four]

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -269,27 +269,43 @@ class RandomEnglishGenerator
             }
 
             // ---- we are now getting a random word from a file ----
-
-            // note the suffix of the word, and append this to the random word
-            $restOfWord = \str_replace($start, '', $possiblyRandomWord);
-
-            // This avoids having to use 'countrie' in the sentence structure file : country -> countries
-            $wordType = \str_replace('country', 'countrie', $wordType);
-
-            /** @var string $randomWord */
-            $randomWord = $this->getRandomWord($wordType);
-
-            // augment the random word if a plural noun or an ing verb
-            $this->augmentIfPluralNoun($pluralNoun, $randomWord);
-            $this->augmentIfIngVerb($ing, $randomWord);
-
-            // add the random word, and then the suffix of the word such as ?! or !!
-            $result = $randomWord . $restOfWord;
+            $result = $this->chooseRandomWord($possiblyRandomWord, $wordType, $pluralNoun, $ing);
 
             break;
         }
 
         // no randomized word has been found, aka no [verb] or [noun], thus append the possibly random word as is
+        return $result;
+    }
+
+
+    /**
+     * @param string $randomWordTypeWithSuffix
+     * @param string $wordType noun, verb, adjective etc
+     * @param bool $pluralizeNoun if true pluralize a noun
+     * @param bool $makeVerbIng if true make a verb an ing verb, e.g. run -> running
+     * @return string
+     */
+    private function chooseRandomWord(string $randomWordTypeWithSuffix, string $wordType, bool $pluralizeNoun, bool $makeVerbIng): string
+    {
+        $start = '[' . $wordType . ']';
+        error_log('WT:' . $randomWordTypeWithSuffix);
+
+        // note the suffix of the word, and append this to the random word
+        $restOfWord = \str_replace($start, '', $randomWordTypeWithSuffix);
+
+        // This avoids having to use 'countrie' in the sentence structure file : country -> countries
+        $wordType = \str_replace('country', 'countrie', $wordType);
+
+        /** @var string $randomWord */
+        $randomWord = $this->getRandomWord($wordType);
+
+        // augment the random word if a plural noun or an ing verb
+        $this->augmentIfPluralNoun($pluralizeNoun, $randomWord);
+        $this->augmentIfIngVerb($makeVerbIng, $randomWord);
+
+        // add the random word, and then the suffix of the word such as ?! or !!
+        $result = $randomWord . $restOfWord;
         return $result;
     }
 }

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -75,59 +75,16 @@ class RandomEnglishGenerator
         $structures = \explode(\PHP_EOL, $this->config);
         \shuffle($structures);
         $structure = $structures[0];
-        
-        $expression='/[\s]+/';
+
+        $expression = '/[\s]+/';
         $splits = \preg_split($expression, $structure, -1, \PREG_SPLIT_NO_EMPTY);
 
         $sentenceArray = [];
 
         /** @var string $possiblyRandomWord */
         foreach ($splits as $possiblyRandomWord) {
-            $randomized = false;
-
-            foreach (self::POSSIBLE_WORD_TYPES as $wordType) {
-                $pluralNoun = $this->pluralNounCheck($wordType, $possiblyRandomWord);
-                $ing = $this->ingVerbCheck($wordType, $possiblyRandomWord);
-
-                $start = '[' . $wordType . ']';
-
-                // check the start of the word as it may be suffixed by likes of a question of exclamation mark.
-                // If no match for the possible word type continue until the next one
-                if (\substr($possiblyRandomWord, 0, \strlen($start)) !== $start) {
-                    continue;
-                }
-
-                // ---- we are now getting a random word from a file ----
-
-                // note the suffix of the word, and append this to the random word
-                $restOfWord = \str_replace($start, '', $possiblyRandomWord);
-
-                // This avoids having to use 'countrie' in the sentence structure file : country -> countries
-                $wordType = \str_replace('country', 'countrie', $wordType);
-
-                /** @var string $randomWord */
-                $randomWord = $this->getRandomWord($wordType);
-
-                // augment the random word if a plural noun or an ing verb
-                $this->augmentIfPluralNoun($pluralNoun, $randomWord);
-                $this->augmentIfIngVerb($ing, $randomWord);
-
-                // add the random word, and then the suffix of the word such as ?! or !!
-                $sentenceArray[] =$randomWord . $restOfWord;
-
-                // flag as randomized
-                $randomized = true;
-
-                break;
-            }
-
-            // if we have found a randomized word, skill to the next word in the sentence
-            if ($randomized) {
-                continue;
-            }
-
-            // no randomized word has been found, aka no [verb] or [noun], thus append the possibly random word as is
-            $sentenceArray[] = $possiblyRandomWord;
+            $word = $this->getWordOrRandomWord($possiblyRandomWord);
+            $sentenceArray[] = $word;
         }
 
         $result = $this->makeArrayIntoSentence($sentenceArray);
@@ -159,7 +116,7 @@ class RandomEnglishGenerator
         $nParagraph = \rand(1, $maxSentences);
         $sentences = [];
 
-        for ($i=0; $i< $nParagraph; $i++) {
+        for ($i = 0; $i < $nParagraph; $i++) {
             $sentences[] = $this->sentence();
         }
 
@@ -286,5 +243,48 @@ class RandomEnglishGenerator
         \shuffle($words);
 
         return $words[0];
+    }
+
+
+    /** @return string the above string as is, or a possibly randomized version, e.g. a random noun */
+    private function getWordOrRandomWord(string $possiblyRandomWord): string
+    {
+        $result = $possiblyRandomWord;
+
+        foreach (self::POSSIBLE_WORD_TYPES as $wordType) {
+            $pluralNoun = $this->pluralNounCheck($wordType, $possiblyRandomWord);
+            $ing = $this->ingVerbCheck($wordType, $possiblyRandomWord);
+
+            $start = '[' . $wordType . ']';
+
+            // check the start of the word as it may be suffixed by likes of a question of exclamation mark.
+            // If no match for the possible word type continue until the next one
+            if (\substr($possiblyRandomWord, 0, \strlen($start)) !== $start) {
+                continue;
+            }
+
+            // ---- we are now getting a random word from a file ----
+
+            // note the suffix of the word, and append this to the random word
+            $restOfWord = \str_replace($start, '', $possiblyRandomWord);
+
+            // This avoids having to use 'countrie' in the sentence structure file : country -> countries
+            $wordType = \str_replace('country', 'countrie', $wordType);
+
+            /** @var string $randomWord */
+            $randomWord = $this->getRandomWord($wordType);
+
+            // augment the random word if a plural noun or an ing verb
+            $this->augmentIfPluralNoun($pluralNoun, $randomWord);
+            $this->augmentIfIngVerb($ing, $randomWord);
+
+            // add the random word, and then the suffix of the word such as ?! or !!
+            $result = $randomWord . $restOfWord;
+
+            break;
+        }
+
+        // no randomized word has been found, aka no [verb] or [noun], thus append the possibly random word as is
+        return $result;
     }
 }

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -90,8 +90,6 @@ class RandomEnglishGenerator
         $result = $this->makeArrayIntoSentence($sentenceArray);
         $this->augmentSentenceTitleCase($titleCase, $result);
 
-        $this->fixEndOfSentence($result);
-
         return $result;
     }
 
@@ -133,23 +131,13 @@ class RandomEnglishGenerator
     }
 
 
-    /** @return string a plural verb */
-    public function pluralVerb(): string
-    {
-        // @todo Choose a random verb source file
-        $plurableNoun = $this->getRandomWord('verb');
-
-        return $plurableNoun . 's';
-    }
-
-
-    /** @return string doing version of a verb */
+    /** @return string the ing version of a verb, e.g. run -> running */
     public function verbing(): string
     {
         // @todo Choose a random verb source file
-        $plurableNoun = $this->getRandomWord('verb');
+        $ingVerb = $this->getRandomWord('verb');
 
-        return $plurableNoun . 'ing';
+        return $ingVerb . 'ing';
     }
 
 
@@ -215,16 +203,33 @@ class RandomEnglishGenerator
     }
 
 
-    /** @param array<string> $sentenceArray */
+    /**
+     * Convert an array of strings into a sentence
+     * 1) Capitalize first letter
+     * 2) Glue words together with a space
+     * 3) Add a full stop
+     * 4) Deal with diferent sentence endings such as ! or ?
+     *
+     * @param array<string> $sentenceArray a sentence whose words are in an array of strings
+     * @return string a sentence
+     */
     public function makeArrayIntoSentence(array $sentenceArray): string
     {
-// ensure sentence starts with a capital
+        // ensure sentence starts with a capital
         $sentenceArray[0] = \ucfirst($sentenceArray[0]);
 
-        return \implode(" ", $sentenceArray) . '.';
+        $sentence = \implode(" ", $sentenceArray) . '.';
+        $this->fixEndOfSentence($sentence);
+
+        return $sentence;
     }
 
 
+    /**
+     * If a sentence ended with a question or exclamation mark prior to having a full stop appended, deal with it
+     *
+     * @param string $result The sentence, by reference, prior to being fixed
+     */
     public function fixEndOfSentence(string &$result): void
     {
         $result = \str_replace('?.', '?', $result);

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -130,15 +130,10 @@ class RandomEnglishGenerator
             $sentenceArray[] = $possiblyRandomWord;
         }
 
-        // ensure sentence starts with a capital
-        $sentenceArray[0] = \ucfirst($sentenceArray[0]);
-
-        $result = \implode(" ", $sentenceArray) . '.';
-
+        $result = $this->makeArrayIntoSentence($sentenceArray);
         $this->augmentSentenceTitleCase($titleCase, $result);
 
-        $result = \str_replace('?.', '?', $result);
-        $result = \str_replace('!.', '?', $result);
+        $this->fixEndOfSentence($result);
 
         return $result;
     }
@@ -260,6 +255,23 @@ class RandomEnglishGenerator
 
         $result = \ucwords($result);
         $result = \substr_replace($result, "", -1);
+    }
+
+
+    /** @param array<string> $sentenceArray */
+    public function makeArrayIntoSentence(array $sentenceArray): string
+    {
+// ensure sentence starts with a capital
+        $sentenceArray[0] = \ucfirst($sentenceArray[0]);
+
+        return \implode(" ", $sentenceArray) . '.';
+    }
+
+
+    public function fixEndOfSentence(string &$result): void
+    {
+        $result = \str_replace('?.', '?', $result);
+        $result = \str_replace('!.', '?', $result);
     }
 
 

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -256,9 +256,9 @@ class RandomEnglishGenerator
     {
         $result = $possiblyRandomWord;
 
-        if (strstr($possiblyRandomWord, '|')) {
-            $splits = explode('|', $possiblyRandomWord);
-            shuffle($splits);
+        if (\strstr($possiblyRandomWord, '|')) {
+            $splits = \explode('|', $possiblyRandomWord);
+            \shuffle($splits);
             $result = $splits[0];
         } else {
             foreach (self::POSSIBLE_WORD_TYPES as $wordType) {
@@ -280,22 +280,22 @@ class RandomEnglishGenerator
             }
         }
 
-
-
         // no randomized word has been found, aka no [verb] or [noun], thus append the possibly random word as is
         return $result;
     }
 
 
     /**
-     * @param string $randomWordTypeWithSuffix
      * @param string $wordType noun, verb, adjective etc
      * @param bool $pluralizeNoun if true pluralize a noun
      * @param bool $makeVerbIng if true make a verb an ing verb, e.g. run -> running
-     * @return string
      */
-    private function chooseRandomWord(string $randomWordTypeWithSuffix, string $wordType, bool $pluralizeNoun, bool $makeVerbIng): string
-    {
+    private function chooseRandomWord(
+        string $randomWordTypeWithSuffix,
+        string $wordType,
+        bool $pluralizeNoun,
+        bool $makeVerbIng
+    ): string {
         $start = '[' . $wordType . ']';
        // error_log('WT:' . $randomWordTypeWithSuffix);
 
@@ -313,7 +313,6 @@ class RandomEnglishGenerator
         $this->augmentIfIngVerb($makeVerbIng, $randomWord);
 
         // add the random word, and then the suffix of the word such as ?! or !!
-        $result = $randomWord . $restOfWord;
-        return $result;
+        return $randomWord . $restOfWord;
     }
 }

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -135,10 +135,7 @@ class RandomEnglishGenerator
 
         $result = \implode(" ", $sentenceArray) . '.';
 
-        if ($titleCase) {
-            $result = \ucwords($result);
-            $result = \substr_replace($result, "", -1);
-        }
+        $this->augmentSentenceTitleCase($titleCase, $result);
 
         $result = \str_replace('?.', '?', $result);
         $result = \str_replace('!.', '?', $result);
@@ -244,14 +241,25 @@ class RandomEnglishGenerator
     }
 
 
-    public function augmentIfIngVerb(bool $ing, string &$randomWord): string
+    public function augmentIfIngVerb(bool $ing, string &$randomWord): void
     {
-        if ($ing) {
-            $helper = new LanguageHelper();
-            $randomWord = $helper->ingVerb($randomWord);
+        if (!$ing) {
+            return;
         }
 
-        return $randomWord;
+        $helper = new LanguageHelper();
+        $randomWord = $helper->ingVerb($randomWord);
+    }
+
+
+    public function augmentSentenceTitleCase(bool $titleCase, string &$result): void
+    {
+        if (!$titleCase) {
+            return;
+        }
+
+        $result = \ucwords($result);
+        $result = \substr_replace($result, "", -1);
     }
 
 

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -256,23 +256,31 @@ class RandomEnglishGenerator
     {
         $result = $possiblyRandomWord;
 
-        foreach (self::POSSIBLE_WORD_TYPES as $wordType) {
-            $pluralNoun = $this->pluralNounCheck($wordType, $possiblyRandomWord);
-            $ing = $this->ingVerbCheck($wordType, $possiblyRandomWord);
+        if (strstr($possiblyRandomWord, '|')) {
+            $splits = explode('|', $possiblyRandomWord);
+            shuffle($splits);
+            $result = $splits[0];
+        } else {
+            foreach (self::POSSIBLE_WORD_TYPES as $wordType) {
+                $pluralNoun = $this->pluralNounCheck($wordType, $possiblyRandomWord);
+                $ing = $this->ingVerbCheck($wordType, $possiblyRandomWord);
 
-            $start = '[' . $wordType . ']';
+                $start = '[' . $wordType . ']';
 
-            // check the start of the word as it may be suffixed by likes of a question of exclamation mark.
-            // If no match for the possible word type continue until the next one
-            if (\substr($possiblyRandomWord, 0, \strlen($start)) !== $start) {
-                continue;
+                // check the start of the word as it may be suffixed by likes of a question of exclamation mark.
+                // If no match for the possible word type continue until the next one
+                if (\substr($possiblyRandomWord, 0, \strlen($start)) !== $start) {
+                    continue;
+                }
+
+                // ---- we are now getting a random word from a file ----
+                $result = $this->chooseRandomWord($possiblyRandomWord, $wordType, $pluralNoun, $ing);
+
+                break;
             }
-
-            // ---- we are now getting a random word from a file ----
-            $result = $this->chooseRandomWord($possiblyRandomWord, $wordType, $pluralNoun, $ing);
-
-            break;
         }
+
+
 
         // no randomized word has been found, aka no [verb] or [noun], thus append the possibly random word as is
         return $result;
@@ -289,7 +297,7 @@ class RandomEnglishGenerator
     private function chooseRandomWord(string $randomWordTypeWithSuffix, string $wordType, bool $pluralizeNoun, bool $makeVerbIng): string
     {
         $start = '[' . $wordType . ']';
-        error_log('WT:' . $randomWordTypeWithSuffix);
+       // error_log('WT:' . $randomWordTypeWithSuffix);
 
         // note the suffix of the word, and append this to the random word
         $restOfWord = \str_replace($start, '', $randomWordTypeWithSuffix);

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -108,25 +108,25 @@ class RandomEnglishGenerator
                 /** @var string $randomWord */
                 $randomWord = $this->getRandomWord($wordType);
 
-                if ($pluralNoun) {
-                    $helper = new LanguageHelper();
-                    $randomWord = $helper->pluralizeNoun($randomWord);
-                }
+                // augment the random word if a plural noun or an ing verb
+                $this->augmentIfPluralNoun($pluralNoun, $randomWord);
+                $this->augmentIfIngVerb($ing, $randomWord);
 
-                if ($ing) {
-                    $helper = new LanguageHelper();
-                    $randomWord = $helper->ingVerb($randomWord);
-                }
+                // add the random word, and then the suffix of the word such as ?! or !!
                 $sentenceArray[] =$randomWord . $restOfWord;
+
+                // flag as randomized
                 $randomized = true;
 
                 break;
             }
 
+            // if we have found a randomized word, skill to the next word in the sentence
             if ($randomized) {
                 continue;
             }
 
+            // no randomized word has been found, aka no [verb] or [noun], thus append the possibly random word as is
             $sentenceArray[] = $possiblyRandomWord;
         }
 
@@ -230,6 +230,28 @@ class RandomEnglishGenerator
         }
 
         return $ing;
+    }
+
+
+    public function augmentIfPluralNoun(bool $pluralNoun, string &$randomWord): void
+    {
+        if (!$pluralNoun) {
+            return;
+        }
+
+        $helper = new LanguageHelper();
+        $randomWord = $helper->pluralizeNoun($randomWord);
+    }
+
+
+    public function augmentIfIngVerb(bool $ing, string &$randomWord): string
+    {
+        if ($ing) {
+            $helper = new LanguageHelper();
+            $randomWord = $helper->ingVerb($randomWord);
+        }
+
+        return $randomWord;
     }
 
 

--- a/src/RandomEnglishGenerator.php
+++ b/src/RandomEnglishGenerator.php
@@ -81,36 +81,38 @@ class RandomEnglishGenerator
 
         $sentenceArray = [];
 
+        /** @var string $possiblyRandomWord */
         foreach ($splits as $possiblyRandomWord) {
             $randomized = false;
 
             foreach (self::POSSIBLE_WORD_TYPES as $wordType) {
-                $pluralNoun = ($wordType === 'plural_noun');
-                if ($pluralNoun) {
-                    $wordType = 'noun';
-                    $possiblyRandomWord = \str_replace('plural_', '', $possiblyRandomWord);
-                }
+                $pluralNoun = $this->pluralNounCheck($wordType, $possiblyRandomWord);
+                $ing = $this->ingVerbCheck($wordType, $possiblyRandomWord);
 
-                $ing = \substr($wordType, -4)=== '_ing';
-                if ($ing) {
-                    $wordType = \str_replace('_ing', '', $wordType);
-                    $possiblyRandomWord = \str_replace('_ing', '', $possiblyRandomWord);
-                }
                 $start = '[' . $wordType . ']';
 
+                // check the start of the word as it may be suffixed by likes of a question of exclamation mark.
+                // If no match for the possible word type continue until the next one
                 if (\substr($possiblyRandomWord, 0, \strlen($start)) !== $start) {
                     continue;
                 }
 
+                // ---- we are now getting a random word from a file ----
+
+                // note the suffix of the word, and append this to the random word
                 $restOfWord = \str_replace($start, '', $possiblyRandomWord);
-                // country -> countries
+
+                // This avoids having to use 'countrie' in the sentence structure file : country -> countries
                 $wordType = \str_replace('country', 'countrie', $wordType);
+
+                /** @var string $randomWord */
                 $randomWord = $this->getRandomWord($wordType);
+
                 if ($pluralNoun) {
                     $helper = new LanguageHelper();
-
                     $randomWord = $helper->pluralizeNoun($randomWord);
                 }
+
                 if ($ing) {
                     $helper = new LanguageHelper();
                     $randomWord = $helper->ingVerb($randomWord);
@@ -125,8 +127,7 @@ class RandomEnglishGenerator
                 continue;
             }
 
-            $sentenceArray[] =
-                $possiblyRandomWord;
+            $sentenceArray[] = $possiblyRandomWord;
         }
 
         // ensure sentence starts with a capital
@@ -200,6 +201,35 @@ class RandomEnglishGenerator
         $plurableNoun = $this->getRandomWord('verb');
 
         return $plurableNoun . 'ing';
+    }
+
+
+    /**
+     * @param string $wordType The word type, e.g. 'noun' or 'verb'
+     * @return bool true if this is a plural noun
+     */
+    public function pluralNounCheck(string &$wordType, string &$possiblyRandomWord): bool
+    {
+        $pluralNoun = ($wordType === 'plural_noun');
+        if ($pluralNoun) {
+            $wordType = 'noun';
+            $possiblyRandomWord = \str_replace('plural_', '', $possiblyRandomWord);
+        }
+
+        return $pluralNoun;
+    }
+
+
+    /** @return bool true if this is a verb with ing */
+    public function ingVerbCheck(string &$wordType, string &$possiblyRandomWord): bool
+    {
+        $ing = \substr($wordType, -4) === '_ing';
+        if ($ing) {
+            $wordType = \str_replace('_ing', '', $wordType);
+            $possiblyRandomWord = \str_replace('_ing', '', $possiblyRandomWord);
+        }
+
+        return $ing;
     }
 
 

--- a/tests/RandomEnglishGeneratorTest.php
+++ b/tests/RandomEnglishGeneratorTest.php
@@ -56,6 +56,32 @@ class RandomEnglishGeneratorTest extends TestCase
     }
 
 
+    public function testRandomCountry(): void
+    {
+        $generator = new RandomEnglishGenerator();
+        $generator->setConfig('Can I go on holiday to [country] due to Covid 19?');
+        $this->assertEquals('Can I go on holiday to Saint Lucia due to Covid 19?', $generator->sentence());
+    }
+
+
+    public function testRandomColour(): void
+    {
+        $generator = new RandomEnglishGenerator();
+        $generator->setConfig('I like [colour]');
+        $this->assertEquals('I like saddle brown.', $generator->sentence());
+    }
+
+    public function testRandomWordVerticalBars()
+    {
+        $generator = new RandomEnglishGenerator();
+        $generator->setConfig('a|b|c|d');
+        for($i=0; $i<100; $i++) {
+            $sentence = $generator->sentence();
+            $this->assertTrue(in_array($sentence, ['A.', 'B.', 'C.', 'D.']));
+        }
+    }
+
+
     public function testPluralNoun(): void
     {
         $generator = new RandomEnglishGenerator();

--- a/tests/RandomEnglishGeneratorTest.php
+++ b/tests/RandomEnglishGeneratorTest.php
@@ -71,13 +71,14 @@ class RandomEnglishGeneratorTest extends TestCase
         $this->assertEquals('I like saddle brown.', $generator->sentence());
     }
 
-    public function testRandomWordVerticalBars()
+
+    public function testRandomWordVerticalBars(): void
     {
         $generator = new RandomEnglishGenerator();
         $generator->setConfig('a|b|c|d');
-        for($i=0; $i<100; $i++) {
+        for ($i=0; $i<100; $i++) {
             $sentence = $generator->sentence();
-            $this->assertTrue(in_array($sentence, ['A.', 'B.', 'C.', 'D.']));
+            $this->assertTrue(\in_array($sentence, ['A.', 'B.', 'C.', 'D.'], true));
         }
     }
 


### PR DESCRIPTION
## Description
Allow for an inline list of explicit random words such as `[one|two|three|four]` in sentence structure config

## Motivation and context

Closes #7
